### PR TITLE
Add ferris sweep (cradio) configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,22 @@ jobs:
     container:
       image: zmkfirmware/zmk-build-arm:stable
     name: Build
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - board: nice_nano
+            shield: sofle_left
+            name: sofle
+          - board: nice_nano
+            shield: sofle_right
+            name: sofle
+          - board: nice_nano_v2
+            shield: cradio_left
+            name: sweep
+          - board: nice_nano_v2
+            shield: cradio_right
+            name: sweep
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,26 +49,12 @@ jobs:
         run: west update
       - name: West Zephyr export
         run: west zephyr-export
-      - name: West Build (Sofle Left)
-        run: west build -s zmk/app -b nice_nano -- -DSHIELD=sofle_left -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
-      - name: Sofle Left Kconfig file
-        run: cat build/zephyr/.config | grep -v "^#" | grep -v "^$"
+      - name: West Build (${{ matrix.shield }})
+        run: west build --pristine -s zmk/app -b ${{ matrix.board }} -- -DSHIELD=${{ matrix.shield }} -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
       - name: Rename zmk.uf2
-        run: cp build/zephyr/zmk.uf2 sofle_left_nice_nano.uf2
-      - name: Archive (Sofle Left)
+        run: cp build/zephyr/zmk.uf2 ${{ matrix.shield }}_${{ matrix.board }}.uf2
+      - name: Archive (${{ matrix.shield }})
         uses: actions/upload-artifact@v2
         with:
-          name: firmware
-          path: sofle_left_nice_nano.uf2
-      - name: West Build (Sofle Right)
-        run: west build --pristine -s zmk/app -b nice_nano -- -DSHIELD=sofle_right -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
-
-      - name: Sofle Right Kconfig file
-        run: cat build/zephyr/.config | grep -v "^#" | grep -v "^$"
-      - name: Rename zmk.uf2
-        run: cp build/zephyr/zmk.uf2 sofle_right_nice_nano.uf2
-      - name: Archive (Sofle Right)
-        uses: actions/upload-artifact@v2
-        with:
-          name: firmware
-          path: sofle_right_nice_nano.uf2
+          name: ${{ matrix.name }}-firmware
+          path: ${{ matrix.shield }}_${{ matrix.board }}.uf2

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -87,4 +87,15 @@
         };
 
     };
+
+    combos {
+        compatible = "zmk,combos";
+
+        combo_esc {
+            bindings = <&kp ESC>;
+            key-positions = <30 31>;
+            layers = <DFLT>;
+            timeout-ms = <50>;
+        };
+    };
 };

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -4,12 +4,12 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 
+#define DFLT 0
 #define MEDR 1
 #define NAVR 2
-#define MSE  3
-#define NSSL 4
-#define NSL  5
-#define FUNL 6
+#define NSSL 3
+#define NSL  4
+#define FUNL 5
 
 / {
     behaviour {
@@ -27,7 +27,7 @@
     keymap {
         compatible = "zmk,keymap";
 
-        default_layer {
+        DFLT {
 //    -------------------------------------------------------------------------
 //  0 |  Q  |  W  |  F  |  P  |  B  |  4      5 |  J  |  L  |  U  |  Y  |  '  |  9
 // 10 |  A  |  R  |  S  |  T  |  G  | 14     15 |  M  |  N  |  E  |  I  |  O  | 19
@@ -37,7 +37,7 @@
 &kp Q      &kp W      &kp F       &kp P       &kp B           &kp J  &kp L       &kp U       &kp Y       &kp APOS
 &hm LALT A &hm LGUI R &hm LSHFT S &hm LCTRL T &kp G           &kp M  &hm RCTRL N &hm RSHFT E &hm RGUI I  &hm LALT O
 &kp Z      &kp X      &kp C       &kp D       &kp V           &kp K  &kp H       &kp COMMA   &kp DOT     &kp FSLH
-                            &lt NAVR SPACE &lt MSE TAB     &lt NSSL RET  &lt NSL BSPC
+                           &lt NAVR SPACE &lt MEDR TAB     &lt NSSL RET  &lt NSL BSPC
             >;
         };
 
@@ -58,13 +58,6 @@
                      &trans &trans       &trans     &trans
             >;
         };
-
-        /*
-        MSE {
-            bindings = <
-            >;
-        };
-        */
 
         NSSL {
             bindings = <

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -97,5 +97,21 @@
             layers = <DFLT>;
             timeout-ms = <50>;
         };
+
+        /*
+        combo_minus {
+            bindings = <&kp MINUS>;
+            key-positions = <30 31>;
+            layers = <NSL>;
+            timeout-ms = <50>;
+        };
+        */
+
+        combo_under {
+            bindings = <&kp UNDER>;
+            key-positions = <30 31>;
+            layers = <NSSL>;
+            timeout-ms = <50>;
+        };
     };
 };

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -1,0 +1,97 @@
+// vim: filetype=dts:ts=4:sw=4:et
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+#define MEDR 1
+#define NAVR 2
+#define MSE  3
+#define NSSL 4
+#define NSL  5
+#define FUNL 6
+
+/ {
+    behaviour {
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HOMEROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <175>;
+            quick_tap_ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+//    -------------------------------------------------------------------------
+//  0 |  Q  |  W  |  F  |  P  |  B  |  4      5 |  J  |  L  |  U  |  Y  |  '  |  9
+// 10 |  A  |  R  |  S  |  T  |  G  | 14     15 |  M  |  N  |  E  |  I  |  O  | 19
+// 20 |  Z  |  X  |  C  |  D  |  V  | 24     25 |  K  |  H  |  ,  |  .  |  /  | 29
+//                   30 |SPACE| TAB | 31     32 | RET | BSPC| 33
+            bindings = <
+&kp Q      &kp W      &kp F       &kp P       &kp B           &kp J  &kp L       &kp U       &kp Y       &kp APOS
+&hm LALT A &hm LGUI R &hm LSHFT S &hm LCTRL T &kp G           &kp M  &hm RCTRL N &hm RSHFT E &hm RGUI I  &hm LALT O
+&kp Z      &kp X      &kp C       &kp D       &kp V           &kp K  &kp H       &kp COMMA   &kp DOT     &kp FSLH
+                            &lt NAVR SPACE &lt MSE TAB     &lt NSSL RET  &lt NSL BSPC
+            >;
+        };
+
+        MEDR {
+            bindings = <
+&trans &trans &trans &trans &trans       &trans     &trans     &trans       &trans       &trans
+&trans &trans &trans &trans &trans       &trans     &kp K_PREV &kp K_VOL_DN &kp K_VOL_UP &kp K_NEXT
+&trans &trans &trans &trans &trans       &trans     &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3
+                     &trans &trans       &kp K_MUTE &kp K_PP
+            >;
+        };
+
+        NAVR {
+            bindings = <
+&trans &trans &trans &trans &trans       &kp K_REDO &kp K_PASTE &kp K_COPY &kp K_CUT &kp K_UNDO
+&trans &trans &trans &trans &trans       &kp INS    &kp LEFT    &kp DOWN   &kp UP    &kp RIGHT
+&trans &trans &trans &trans &trans       &kp CAPS   &kp HOME    &kp PG_DN  &kp PG_UP &kp END
+                     &trans &trans       &trans     &trans
+            >;
+        };
+
+        /*
+        MSE {
+            bindings = <
+            >;
+        };
+        */
+
+        NSSL {
+            bindings = <
+&kp LBRC  &kp AMPS &kp STAR  &kp NON_US_BSLH &kp RBRC       &trans &trans &trans &trans &trans
+&kp COLON &kp DLLR &kp PRCNT &kp CARET       &kp PLUS       &trans &trans &trans &trans &trans
+&kp TILDE &kp EXCL &kp AT    &kp HASH        &kp PIPE       &trans &trans &trans &trans &trans
+                             &kp LPAR        &kp RPAR       &trans &trans
+            >;
+        };
+
+        NSL {
+            bindings = <
+&kp LBKT  &kp N7 &kp N8 &kp N9 &kp RBKT        &trans &trans &trans &trans &trans
+&kp SEMI  &kp N4 &kp N5 &kp N6 &kp EQUAL       &trans &trans &trans &trans &trans
+&kp GRAVE &kp N1 &kp N2 &kp N3 &kp BSLH        &trans &trans &trans &trans &trans
+                        &kp N0 &kp MINUS       &trans &trans
+            >;
+        };
+
+        FUNL {
+            bindings = <
+&kp F12 &kp F7 &kp F8 &kp F9    &kp PSCRN             &trans &trans &trans &trans &trans
+&kp F11 &kp F4 &kp F5 &kp F6    &kp SLCK              &trans &trans &trans &trans &trans
+&kp F10 &kp F1 &kp F2 &kp F3    &kp PAUSE_BREAK       &trans &trans &trans &trans &trans
+                      &kp K_APP &trans                &trans &trans
+            >;
+        };
+
+    };
+};

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -43,36 +43,36 @@
 
         MEDR {
             bindings = <
-&trans &trans &trans &trans &trans       &trans     &trans     &trans       &trans       &trans
-&trans &trans &trans &trans &trans       &trans     &kp K_PREV &kp K_VOL_DN &kp K_VOL_UP &kp K_NEXT
-&trans &trans &trans &trans &trans       &trans     &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3
-                     &trans &trans       &kp K_MUTE &kp K_PP
+&trans &trans &trans    &trans    &trans       &trans     &trans     &trans       &trans       &trans
+&trans &trans &trans    &trans    &trans       &trans     &kp K_PREV &kp K_VOL_DN &kp K_VOL_UP &kp K_NEXT
+&trans &trans &tog NSSL &tog MEDR &trans       &trans     &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3
+                        &trans    &trans       &kp K_MUTE &kp K_PP
             >;
         };
 
         NAVR {
             bindings = <
-&trans &trans &trans &trans &trans       &kp K_REDO &kp K_PASTE &kp K_COPY &kp K_CUT &kp K_UNDO
-&trans &trans &trans &trans &trans       &kp INS    &kp LEFT    &kp DOWN   &kp UP    &kp RIGHT
-&trans &trans &trans &trans &trans       &kp CAPS   &kp HOME    &kp PG_DN  &kp PG_UP &kp END
-                     &trans &trans       &trans     &trans
+&trans &trans &trans   &trans    &trans       &kp K_REDO &kp K_PASTE &kp K_COPY &kp K_CUT &kp K_UNDO
+&trans &trans &trans   &trans    &trans       &kp INS    &kp LEFT    &kp DOWN   &kp UP    &kp RIGHT
+&trans &trans &tog NSL &tog NAVR &trans       &kp CAPS   &kp HOME    &kp PG_DN  &kp PG_UP &kp END
+                       &trans    &trans       &trans     &trans
             >;
         };
 
         NSSL {
             bindings = <
-&kp LBRC  &kp AMPS &kp STAR  &kp NON_US_BSLH &kp RBRC       &trans &trans &trans &trans &trans
-&kp COLON &kp DLLR &kp PRCNT &kp CARET       &kp PLUS       &trans &trans &trans &trans &trans
-&kp TILDE &kp EXCL &kp AT    &kp HASH        &kp PIPE       &trans &trans &trans &trans &trans
+&kp LBRC  &kp AMPS &kp STAR  &kp NON_US_BSLH &kp RBRC       &trans &trans    &trans    &trans &trans
+&kp COLON &kp DLLR &kp PRCNT &kp CARET       &kp PLUS       &trans &trans    &trans    &trans &trans
+&kp TILDE &kp EXCL &kp AT    &kp HASH        &kp PIPE       &trans &tog NSSL &tog MEDR &trans &trans
                              &kp LPAR        &kp RPAR       &trans &trans
             >;
         };
 
         NSL {
             bindings = <
-&kp LBKT  &kp N7 &kp N8 &kp N9 &kp RBKT        &trans &trans &trans &trans &trans
-&kp SEMI  &kp N4 &kp N5 &kp N6 &kp EQUAL       &trans &trans &trans &trans &trans
-&kp GRAVE &kp N1 &kp N2 &kp N3 &kp BSLH        &trans &trans &trans &trans &trans
+&kp LBKT  &kp N7 &kp N8 &kp N9 &kp RBKT        &trans &trans   &trans    &trans &trans
+&kp SEMI  &kp N4 &kp N5 &kp N6 &kp EQUAL       &trans &trans   &trans    &trans &trans
+&kp GRAVE &kp N1 &kp N2 &kp N3 &kp BSLH        &trans &tog NSL &tog NAVR &trans &trans
                         &kp N0 &kp MINUS       &trans &trans
             >;
         };

--- a/config/sofle.keymap
+++ b/config/sofle.keymap
@@ -53,21 +53,21 @@
 
         MEDR {
             bindings = <
-&trans &trans &trans &trans &trans &trans                    &trans   &trans     &trans       &trans       &trans     &trans
-&trans &trans &trans &trans &trans &trans                    &trans   &trans     &trans       &trans       &trans     &trans
-&trans &trans &trans &trans &trans &trans                    &trans   &kp K_PREV &kp K_VOL_DN &kp K_VOL_UP &kp K_NEXT &trans
-&trans &trans &trans &trans &trans &trans &trans &trans      &trans   &trans     &trans       &trans       &trans     &trans
-              &trans &trans &trans &trans &trans &kp K_STOP2 &kp K_PP &kp K_MUTE &trans       &trans
+&trans &trans &trans &trans    &trans    &trans                    &trans   &trans     &trans       &trans       &trans     &trans
+&trans &trans &trans &trans    &trans    &trans                    &trans   &trans     &trans       &trans       &trans     &trans
+&trans &trans &trans &trans    &trans    &trans                    &trans   &kp K_PREV &kp K_VOL_DN &kp K_VOL_UP &kp K_NEXT &trans
+&trans &trans &trans &tog FUNL &tog MEDR &trans &trans &trans      &trans   &trans     &trans       &trans       &trans     &trans
+              &trans &trans    &trans    &trans &trans &kp K_STOP2 &kp K_PP &kp K_MUTE &trans       &trans
             >;
         };
 
         NAVR {
             bindings = <
-&trans &trans &trans &trans &trans &trans               &trans     &trans      &trans     &trans    &trans     &trans
-&trans &trans &trans &trans &trans &trans               &kp K_REDO &kp K_PASTE &kp K_COPY &kp K_CUT &kp K_UNDO &trans
-&trans &trans &trans &trans &trans &trans               &kp INS    &kp LEFT    &kp DOWN   &kp UP    &kp RIGHT  &trans
-&trans &trans &trans &trans &trans &trans &trans &trans &kp CAPS   &kp HOME    &kp PG_DN  &kp PG_UP &kp END    &trans
-              &trans &trans &trans &trans &trans &trans &trans     &trans      &trans     &trans
+&trans &trans &trans &trans   &trans    &trans               &trans     &trans      &trans     &trans    &trans     &trans
+&trans &trans &trans &trans   &trans    &trans               &kp K_REDO &kp K_PASTE &kp K_COPY &kp K_CUT &kp K_UNDO &trans
+&trans &trans &trans &trans   &trans    &trans               &kp INS    &kp LEFT    &kp DOWN   &kp UP    &kp RIGHT  &trans
+&trans &trans &trans &tog NSL &tog NAVR &trans &trans &trans &kp CAPS   &kp HOME    &kp PG_DN  &kp PG_UP &kp END    &trans
+              &trans &trans   &trans    &trans &trans &trans &trans     &trans      &trans     &trans
             >;
         };
 
@@ -77,37 +77,37 @@
 &reset      &trans       &trans       &trans       &trans       &trans               &trans &trans &trans &trans &trans &trans
 &trans      &trans       &bt BT_SEL 4 &bt BT_SEL 5 &bt BT_SEL 6 &trans               &trans &trans &trans &trans &trans &trans
 &bt BT_CLR  &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &trans &trans &trans &trans &trans &trans &trans &trans &trans
-                        &trans        &trans      &trans       &trans &trans &trans &trans &trans &trans &trans
+                        &trans        &trans      &trans        &trans &trans &trans &trans &trans &trans &trans
             >;
         };
 
         NSSL {
             bindings = <
-&trans &trans    &trans   &trans    &trans          &trans                      &trans &trans &trans &trans &trans &trans
-&trans &kp LBRC  &kp AMPS &kp STAR  &kp NON_US_BSLH &kp RBRC                    &trans &trans &trans &trans &trans &trans
-&trans &kp COLON &kp DLLR &kp PRCNT &kp CARET        &kp PLUS                   &trans &trans &trans &trans &trans &trans
-&trans &kp TILDE &kp EXCL &kp AT    &kp HASH         &kp PIPE  &trans    &trans &trans &trans &trans &trans &trans &trans
-                 &trans   &trans    &kp LPAR         &kp RPAR  &kp UNDER &trans &trans &trans &trans &trans
+&trans &trans    &trans   &trans    &trans          &trans                      &trans &trans    &trans &trans &trans &trans
+&trans &kp LBRC  &kp AMPS &kp STAR  &kp NON_US_BSLH &kp RBRC                    &trans &trans    &trans &trans &trans &trans
+&trans &kp COLON &kp DLLR &kp PRCNT &kp CARET        &kp PLUS                   &trans &trans    &trans &trans &trans &trans
+&trans &kp TILDE &kp EXCL &kp AT    &kp HASH         &kp PIPE  &trans    &trans &trans &tog NSSL &trans &trans &trans &trans
+                 &trans   &trans    &kp LPAR         &kp RPAR  &kp UNDER &trans &trans &trans    &trans &trans
             >;
         };
 
         NSL {
             bindings = <
-&trans &trans    &trans &trans &trans  &trans                     &trans &trans &trans &trans &trans &trans
-&trans &kp LBKT  &kp N7 &kp N8 &kp N9  &kp RBKT                   &trans &trans &trans &trans &trans &trans
-&trans &kp SEMI  &kp N4 &kp N5 &kp N6  &kp EQUAL                  &trans &trans &trans &trans &trans &trans
-&trans &kp GRAVE &kp N1 &kp N2 &kp N3  &kp BSLH  &trans    &trans &trans &trans &trans &trans &trans &trans
-                 &trans &trans &kp DOT &kp N0    &kp MINUS &trans &trans &trans &trans &trans
+&trans &trans    &trans &trans &trans  &trans                     &trans &trans    &trans    &trans &trans &trans
+&trans &kp LBKT  &kp N7 &kp N8 &kp N9  &kp RBKT                   &trans &trans    &trans    &trans &trans &trans
+&trans &kp SEMI  &kp N4 &kp N5 &kp N6  &kp EQUAL                  &trans &trans    &trans    &trans &trans &trans
+&trans &kp GRAVE &kp N1 &kp N2 &kp N3  &kp BSLH  &trans    &trans &trans &tog NSL  &tog NAVR &trans &trans &trans
+                 &trans &trans &kp DOT &kp N0    &kp MINUS &trans &trans &trans    &trans    &trans
             >;
         };
 
         FUNL {
             bindings = <
-&trans &trans  &trans &trans &trans    &trans                        &trans &trans &trans &trans &trans &trans
-&trans &kp F12 &kp F7 &kp F8 &kp F9    &kp PSCRN                     &trans &trans &trans &trans &trans &trans
-&trans &kp F11 &kp F4 &kp F5 &kp F6    &kp SLCK                      &trans &trans &trans &trans &trans &trans
-&trans &kp F10 &kp F1 &kp F2 &kp F3    &kp PAUSE_BREAK &trans &trans &trans &trans &trans &trans &trans &trans
-               &trans &trans &kp K_APP &trans          &trans &trans &trans &trans &trans &trans
+&trans &trans  &trans &trans &trans    &trans                        &trans &trans    &trans    &trans &trans &trans
+&trans &kp F12 &kp F7 &kp F8 &kp F9    &kp PSCRN                     &trans &trans    &trans    &trans &trans &trans
+&trans &kp F11 &kp F4 &kp F5 &kp F6    &kp SLCK                      &trans &trans    &trans    &trans &trans &trans
+&trans &kp F10 &kp F1 &kp F2 &kp F3    &kp PAUSE_BREAK &trans &trans &trans &tog FUNL &tog MEDR &trans &trans &trans
+               &trans &trans &kp K_APP &trans          &trans &trans &trans &trans    &trans    &trans
             >;
         };
 

--- a/config/sofle.keymap
+++ b/config/sofle.keymap
@@ -2,6 +2,7 @@
  * Copyright (c) 2020 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
+ * vim: filetype=dts:ts=4:sw=4:et
  */
 
 #include <behaviors.dtsi>


### PR DESCRIPTION
Add a configuration for the ferris sweep based on our custom miryoku
for the smaller thumb cluster this config drops the mouse and function layers as well as the esc, dot and under keys on the left-hand layers, these keys are replaced with combos where neccessary

